### PR TITLE
Chris/int input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ results.csv
 __pycache__*
 *.pyc
 saved_models/*
+saved_models5/*

--- a/save_model.py
+++ b/save_model.py
@@ -5,6 +5,16 @@
 #   python save_model.py
 #
 
+
+""""
+
+Saves the classification model in the tensorflow SavedModel format. 
+See https://www.tensorflow.org/guide/saved_model
+
+The graph is saved such that it expects an image of shape [299,299,3]
+consisting of uint8 values in the range [0,255]
+"""
+
 from inception import inception_model as inception
 import tensorflow as tf
 import os.path
@@ -25,10 +35,19 @@ def main():
 
     # build the tensorflow graph.
     with tf.Graph().as_default() as g:
+        input_shape = [IMAGE_SIZE, IMAGE_SIZE, 3]
+        final_shape = [1, IMAGE_SIZE, IMAGE_SIZE, 3]
         img_placeholder = tf.placeholder(
-            tf.float32, shape=[None, IMAGE_SIZE, IMAGE_SIZE, 3])
+            tf.uint8, shape=input_shape)
         print(img_placeholder.shape)
-        logits, _ = inception.inference(img_placeholder, NUM_CLASSES)
+        # reshape to add batch size dimension
+        img = tf.reshape(img_placeholder, final_shape)
+        # cast to float
+        img = tf.dtypes.cast(img, dtype=tf.float32)
+        # normalize input to values in range [0,1]
+        img = img / 255.0
+        print('Image shape {}'.format(img.shape))
+        logits, _ = inception.inference(img, NUM_CLASSES)
         saver = tf.train.Saver(tf.all_variables())
 
         ckpt = tf.train.get_checkpoint_state(FLAGS.ckpt_dir)

--- a/save_model.py
+++ b/save_model.py
@@ -35,7 +35,7 @@ def main():
 
     # build the tensorflow graph.
     with tf.Graph().as_default() as g:
-        input_shape = [IMAGE_SIZE, IMAGE_SIZE, 3]
+        input_shape = [None, IMAGE_SIZE, IMAGE_SIZE, 3]
         final_shape = [1, IMAGE_SIZE, IMAGE_SIZE, 3]
         img_placeholder = tf.placeholder(
             tf.uint8, shape=input_shape)
@@ -63,7 +63,7 @@ def main():
                 print('Checkpoint loaded')
             else:
                 print('No checkpoint file found')
-            save_dir = './saved_models5'
+            save_dir = './saved_models'
             print(
                 'Saving model for deployment in directory {}'.format(save_dir))
             tf.saved_model.simple_save(sess,

--- a/save_model.py
+++ b/save_model.py
@@ -36,7 +36,7 @@ def main():
     # build the tensorflow graph.
     with tf.Graph().as_default() as g:
         input_shape = [None, IMAGE_SIZE, IMAGE_SIZE, 3]
-        final_shape = [1, IMAGE_SIZE, IMAGE_SIZE, 3]
+        final_shape = [-1, IMAGE_SIZE, IMAGE_SIZE, 3]
         img_placeholder = tf.placeholder(
             tf.uint8, shape=input_shape)
         print(img_placeholder.shape)

--- a/test_classification.py
+++ b/test_classification.py
@@ -43,7 +43,6 @@ def load_image(path):
 
     dir, filename = os.path.split(path)
 
-    skimage.io.imsave("%s/out_%s" % (dir, filename), resized_img)
     return resized_img
 
 
@@ -68,6 +67,8 @@ def main():
         img_placeholder = tf.placeholder(
             tf.float32, shape=[BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE, 3])
         print(img_placeholder.shape)
+        new_size = [IMAGE_SIZE, IMAGE_SIZE]
+        img_placeholder = tf.image.resize_bilinear(img_placeholder, new_size)
         logits, _ = inception.inference(img_placeholder, NUM_CLASSES)
         saver = tf.train.Saver(tf.all_variables())
 


### PR DESCRIPTION
This PR modifies the classification graph so that
```
The graph is saved such that it expects an image of shape [299,299,3]
consisting of uint8 values in the range [0,255]
```

we should now be able to post normal rgb images with integer values to the deployed model, which are much smaller. In the test_classification script it was tested that such regular RGB images produce the expected results